### PR TITLE
feat: Configure `wayland.windowManager.hyprland`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,10 @@
       extraSpecialArgs = { inherit inputs outputs; };
     };
   in {
+    # Modules
+    nixosModules = import ./shared;
+    homeManagerModules = import ./shared;
+
     # Available through 'nixos-rebuild --flake .#hostname'
     nixosConfigurations = {
       mirea-nixos = mkNixOS [ ./nixos ];

--- a/home/apps/kitty.nix
+++ b/home/apps/kitty.nix
@@ -1,0 +1,67 @@
+# INFO: Kitty: fast, feature-rich, GPU based terminal emulator
+
+{ config, pkgs, ... }: let
+  # Launch Kitty instead of xterm
+  kitty-xterm = pkgs.writeShellScriptBin "xterm" /* shell */ ''
+    ${config.programs.kitty.package}/bin/kitty -1 "$@"
+  '';
+
+  inherit (config.theme) colors;
+in {
+  home.packages = [ kitty-xterm ]; # The alias defined above
+  programs.kitty = {
+    enable = true;
+    font = {
+      name = "JetBrainsMono Nerd Font";
+      size = 12;
+    };
+    settings = {
+      # Opacity
+      background_opacity = "0.9";
+
+      # Colors
+      foreground = "#${colors.text}";
+      background = "#${colors.base}";
+
+      # Black
+      color0 = "#${colors.surface0}";
+      color8 = "#${colors.surface1}";
+      # Red
+      color1 = "#${colors.red}";
+      color9 = "#${colors.red}";
+      # Green
+      color2 = "#${colors.green}";
+      color10 = "#${colors.green}";
+      # Yellow
+      color3 = "#${colors.yellow}";
+      color11 = "#${colors.yellow}";
+      # Blue
+      color4 = "#${colors.blue}";
+      color12 = "#${colors.blue}";
+      # Magenta
+      color5 = "#${colors.mauve}";
+      color13 = "#${colors.mauve}";
+      # Purple
+      color6 = "#${colors.teal}";
+      color14 = "#${colors.teal}";
+      # White
+      color7 = "#${colors.text}";
+      color15 = "#${colors.text}";
+
+      selection_background = "#${colors.text}";
+      selection_foreground = "#${colors.base}";
+
+      cursor = "#${colors.text}";
+      cursor_shape = "beam";
+      url_color = "#${colors.surface2}";
+
+      active_border_color = "#${colors.surface1}";
+      inactive_border_color = "#${colors.base}";
+      active_tab_background = "#${colors.base}";
+      active_tab_foreground = "#${colors.text}";
+      inactive_tab_background = "#${colors.base}";
+      inactive_tab_foreground = "#${colors.surface2}";
+      tab_bar_background = "#${colors.base}";
+    };
+  };
+}

--- a/home/default.nix
+++ b/home/default.nix
@@ -1,5 +1,6 @@
 { config, lib, pkgs, ... }: {
   imports = [
+    ./hyprland.nix
   ]; # ++ (builtins.attrValues outputs.homeManagerModules);
 
   nixpkgs = {

--- a/home/default.nix
+++ b/home/default.nix
@@ -1,7 +1,7 @@
-{ config, lib, pkgs, ... }: {
+{ outputs, config, lib, pkgs, ... }: {
   imports = [
     ./hyprland.nix
-  ]; # ++ (builtins.attrValues outputs.homeManagerModules);
+  ] ++ (builtins.attrValues outputs.homeManagerModules);
 
   nixpkgs = {
     config = {
@@ -37,5 +37,14 @@
     username = lib.mkDefault "user";
     homeDirectory = lib.mkDefault "/home/${config.home.username}";
     stateVersion = "23.05";
+  };
+
+  theme = builtins.fromTOML (
+    builtins.readFile ../themes/catppuccin-mocha.toml
+  );
+  
+  # Store the userspace theme in `~/.config` in various formats
+  xdg.configFile = {
+    "theme.json".text = builtins.toJSON config.theme;
   };
 }

--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -1,7 +1,20 @@
+# INFO: Hyprland, the smooth Wayland compositor
+
 { inputs, ... }: {
-  imports = [
-    inputs.hyprland.homeManagerModules.default
-  ];
+  imports = [ inputs.hyprland.homeManagerModules.default ];
+
+  # Extra binary caches to avoid compiling from source
+  nix.settings = {
+    substituters = [
+      "https://cache.nixos.org"
+      "https://hyprland.cachix.org"
+    ];
+    trusted-public-keys = [
+      "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+      "hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc="
+    ];
+  };
+
   wayland.windowManager.hyprland = {
     enable = true;
   };

--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -1,7 +1,10 @@
 # INFO: Hyprland, the smooth Wayland compositor
 
 { inputs, pkgs, ... }: {
-  imports = [ inputs.hyprland.homeManagerModules.default ];
+  imports = [
+    ./apps/kitty.nix
+    inputs.hyprland.homeManagerModules.default
+  ];
 
   # Extra binary caches to avoid compiling from source
   nix.settings = {

--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -15,14 +15,22 @@
     ];
   };
 
+  home.packages = with pkgs; [
+    avizo
+    swww
+    grimblast
+    alsaUtils
+    brillo
+  ];
+
   wayland.windowManager.hyprland = {
     enable = true;
     extraConfig = /* awk */ ''
       # Autostart
-      exec-once = swww init
+      exec-once = ${pkgs.swww}/bin/swww init
       exec-once = ${pkgs.eww-wayland}/bin/eww daemon --restart --force-wayland # TODO
       exec-once = ${pkgs.avizo}/bin/avizo-service
-      exec = sleep 0.5 && swww clear 1e1e2e
+      exec = sleep 0.5 && ${pkgs.swww}/bin/swww clear 1e1e2e
 
       # Kill window | Exit or reload hyprland | Lock screen
       bind =      ALT SHIFT,      Q, killactive,

--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -17,7 +17,7 @@
 
   wayland.windowManager.hyprland = {
     enable = true;
-    extraConfig = /* ini */ ''
+    extraConfig = /* shell */ ''
       bind = ALT, RETURN, exec, ${pkgs.kitty}/bin/kitty # Open a terminal
     '';
   };

--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -17,8 +17,169 @@
 
   wayland.windowManager.hyprland = {
     enable = true;
-    extraConfig = /* shell */ ''
-      bind = ALT, RETURN, exec, ${pkgs.kitty}/bin/kitty # Open a terminal
+    extraConfig = /* awk */ ''
+      # Autostart
+      exec-once = swww init
+      exec-once = ${pkgs.eww-wayland}/bin/eww daemon --restart --force-wayland # TODO
+      exec-once = ${pkgs.avizo}/bin/avizo-service
+      exec = sleep 0.5 && swww clear 1e1e2e
+
+      # Kill window | Exit or reload hyprland | Lock screen
+      bind =      ALT SHIFT,      Q, killactive,
+      bind =      ALT CTRL SHIFT, Q, exec, kill -9 $(hyprctl activewindow -j | jq '.pid')
+      bind =      ALT SHIFT, R, exec, hyprctl reload && eww reload
+
+      # Screenshots
+      bind = , PRINT,      exec, ${pkgs.grimblast}/bin/grimblast copysave output
+      bind = ALT SHIFT, S, exec, ${pkgs.grimblast}/bin/grimblast copysave area
+
+      # Shift focus
+      bind = ALT, H, movefocus, l
+      bind = ALT, J, movefocus, d
+      bind = ALT, K, movefocus, u
+      bind = ALT, L, movefocus, r
+
+      # Move windows within layout
+      bind = ALT SHIFT, H, movewindow, l
+      bind = ALT SHIFT, J, movewindow, d
+      bind = ALT SHIFT, K, movewindow, u
+      bind = ALT SHIFT, L, movewindow, r
+
+      # Float | fullscreen
+      bind = ALT, T, togglefloating,
+      bind = ALT, F, fullscreen,
+
+      # Main apps
+      bind = ALT,       RETURN, exec, ${pkgs.kitty}/bin/kitty
+      bind = ALT,       P,      exec, ${pkgs.kitty}/bin/kitty ${pkgs.bottom}/bin/btm --battery
+
+      # Workspace switching
+      bind = ALT, 1, workspace, 1
+      bind = ALT, 2, workspace, 2
+      bind = ALT, 3, workspace, 3
+      bind = ALT, 4, workspace, 4
+      bind = ALT, 5, workspace, 5
+      bind = ALT, 6, workspace, 6
+      bind = ALT, 7, workspace, 7
+      bind = ALT, 8, workspace, 8
+      bind = ALT, 9, workspace, 9
+      bind = ALT, 0, workspace, 10
+
+      # Move focused window to workspace
+      bind = ALT SHIFT, 1, movetoworkspace, 1
+      bind = ALT SHIFT, 2, movetoworkspace, 2
+      bind = ALT SHIFT, 3, movetoworkspace, 3
+      bind = ALT SHIFT, 4, movetoworkspace, 4
+      bind = ALT SHIFT, 5, movetoworkspace, 5
+      bind = ALT SHIFT, 6, movetoworkspace, 6
+      bind = ALT SHIFT, 7, movetoworkspace, 7
+      bind = ALT SHIFT, 8, movetoworkspace, 8
+      bind = ALT SHIFT, 9, movetoworkspace, 9
+      bind = ALT SHIFT, 0, movetoworkspace, 10
+
+      # Workspace-assigned apps
+      bind = CTRL SHIFT, 1, exec, ${pkgs.kitty}/bin/kitty
+
+      # Brightness
+      bind = , XF86MonBrightnessUp,   exec, ${pkgs.brillo}/bin/brillo -q -A 10 -u 100000
+      bind = , XF86MonBrightnessDown, exec, ${pkgs.brillo}/bin/brillo -q -U 10 -u 100000
+
+      # Volume
+      bind = ALT SHIFT, M,            exec, volumectl toggle-mute
+      bind = , XF86AudioMute,         exec, volumectl toggle-mute
+      bind = , XF86AudioMicMute,      exec, volumectl -m toggle-mute
+      bind = , XF86AudioRaiseVolume,  exec, volumectl -u up
+      bind = , XF86AudioLowerVolume,  exec, volumectl -u down
+
+      # Power button
+      bind = , XF86PowerOff, exec, hyprlock.sh
+
+      # Laptop lid
+      bindl = , switch:on:Lid Switch, exec, hyprlock.sh
+      bindl = , switch:off:Lid Switch, dpms, on
+
+      # Move & resize floating windows
+      bindm = ALT, mouse:272, movewindow
+      bindm = ALT, mouse:273, resizewindow
+
+      # Mouse
+      input {
+        follow_mouse = 1
+        sensitivity = 0.4
+        touchpad {
+          natural_scroll = no
+        }
+
+        # Keyboard
+        kb_layout = us, ru
+        kb_options = grp:win_space_toggle
+      }
+
+      decoration {
+        rounding = 16
+        drop_shadow = true
+        shadow_range = 16
+        col.shadow = rgb(000000)
+
+        dim_inactive = true
+        dim_strength = 0.3
+
+        blur {
+          size = 4
+          passes = 3
+          brightness = 1
+          contrast = 1
+        }
+      }
+
+      general {
+        # Layout
+        layout = dwindle
+        gaps_in = 16
+        gaps_out = 16
+        border_size = 2
+
+        col.active_border = rgb(cba6f7)
+        col.inactive_border = rgb(313244)
+
+        # Mouse & cursor
+        apply_sens_to_raw = 1
+        cursor_inactive_timeout = 5
+        no_cursor_warps = true
+      }
+
+      # Master layout
+      master {
+        special_scale_factor =  0.8
+        new_is_master =         false
+        new_on_top =            false
+        no_gaps_when_only =     false
+      }
+
+      # Dwindle layout
+      dwindle {
+        force_split = 2
+      }
+
+      misc {
+        # Built-in wallpaper things
+        disable_hyprland_logo = true
+        disable_splash_rendering = true
+
+        vfr = true # Variable framerate
+        mouse_move_enables_dpms = true
+        key_press_enables_dpms = true
+      }
+
+      # Fix HiDPI XWayland
+      xwayland {
+        force_zero_scaling = true
+      }
+      env = GDK_SCALE, 2
+      # env = GDK_DPI_SCALE, 2
+
+      # GTK file dialogs
+      windowrulev2 = float, title:^(Open.*)$
     '';
   };
 }

--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -1,0 +1,8 @@
+{ inputs, ... }: {
+  imports = [
+    inputs.hyprland.homeManagerModules.default
+  ];
+  wayland.windowManager.hyprland = {
+    enable = true;
+  };
+}

--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -18,7 +18,7 @@
   wayland.windowManager.hyprland = {
     enable = true;
     extraConfig = /* ini */ ''
-      bind = SUPER, RETURN, exec, ${pkgs.kitty}/bin/kitty # Open a terminal
+      bind = ALT, RETURN, exec, ${pkgs.kitty}/bin/kitty # Open a terminal
     '';
   };
 }

--- a/home/hyprland.nix
+++ b/home/hyprland.nix
@@ -1,6 +1,6 @@
 # INFO: Hyprland, the smooth Wayland compositor
 
-{ inputs, ... }: {
+{ inputs, pkgs, ... }: {
   imports = [ inputs.hyprland.homeManagerModules.default ];
 
   # Extra binary caches to avoid compiling from source
@@ -17,5 +17,8 @@
 
   wayland.windowManager.hyprland = {
     enable = true;
+    extraConfig = /* ini */ ''
+      bind = SUPER, RETURN, exec, ${pkgs.kitty}/bin/kitty # Open a terminal
+    '';
   };
 }

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -3,6 +3,7 @@
     ./hardware.nix
     ./ssh.nix
     ./user.nix
+    ./hyprland.nix # Enable system-wide Hyprland
   ];
 
   # System-wide packages

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }: {
+{ inputs, outputs, pkgs, ... }: {
   imports = [
     ./hardware.nix
     ./ssh.nix
@@ -21,6 +21,11 @@
       experimental-features = [ "nix-command" "flakes" "repl-flake" ];
     };
   };
+
+  home-manager.extraSpecialArgs = { 
+    inherit inputs outputs;
+  };
+
 
   system.stateVersion = "23.05";
   networking.hostName = "mirea-nixos";

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -5,7 +5,7 @@
     ./user.nix
     ./hyprland.nix # Enable system-wide Hyprland
     inputs.home-manager.nixosModules.home-manager
-  ];
+  ] ++ (builtins.attrValues outputs.nixosModules);
 
   # System-wide packages
   environment.systemPackages = with pkgs; [
@@ -28,7 +28,10 @@
     inherit inputs outputs;
   };
 
-
   system.stateVersion = "23.05";
   networking.hostName = "mirea-nixos";
+
+  theme = builtins.fromTOML (
+    builtins.readFile ../themes/catppuccin-mocha.toml
+  );
 }

--- a/nixos/hyprland.nix
+++ b/nixos/hyprland.nix
@@ -1,0 +1,4 @@
+{ inputs, ... }: {
+  imports = [ inputs.hyprland.nixosModules.default ];
+  programs.hyprland.enable = true;
+}

--- a/shared/default.nix
+++ b/shared/default.nix
@@ -1,1 +1,3 @@
-{}
+{
+  rice = import ./rice.nix;
+}

--- a/shared/rice.nix
+++ b/shared/rice.nix
@@ -1,0 +1,7 @@
+{ lib, ... }: {
+  options = {
+    theme = lib.mkOption {
+      type = lib.types.attrs;
+    };
+  };
+}

--- a/themes/catppuccin-mocha.toml
+++ b/themes/catppuccin-mocha.toml
@@ -1,0 +1,35 @@
+[colors]
+# Backgrounds
+crust     = "11111c"
+mantle    = "181825"
+base      = "1e1e2e"
+# Surfaces
+surface0  = "313244"
+surface1  = "45475a"
+surface2  = "585b70"
+# Overlays
+overlay0  = "6c7086"
+overlay1  = "7f849c"
+overlay2  = "9399b2"
+# Texts
+subtext0  = "a6adc8"
+subtext1  = "bac2de"
+text      = "cdd6f4"
+# Accents
+red       = "f38ba8"
+maroon    = "eda0ab"
+peach     = "fab387"
+yellow    = "f9e2af"
+rosewater = "f2cdcd"
+flamingo  = "f5e0dc"
+green     = "a6e3a1"
+teal      = "94e2d5"
+sky       = "98dceb"
+sapphire  = "74c7ec"
+blue      = "89b4fa"
+lavender  = "b4befe"
+mauve     = "cba6f7"
+pink      = "f5c2e7"
+
+[meta]
+url = "https://github.com/catppuccin"


### PR DESCRIPTION
- feat(home): Add minimal `hyprland` module
- chore: Add extra `nix.settings.substituters` for `hyprland`
- feat(hyprland): Add `nixos` module, configure `kitty` bind
- fix(hyprland): Set terminal bind to `ALT, RETURN`
- chore: Change syntax highlighting to `shell` for `hyprland` config
- feat(hyprland): Extend `hyprland.extraConfig`
- fix(hyprland): Add missings `home.packages`
- feat: Add `themes/`, `kitty` terminal, `shared/` modules
